### PR TITLE
Allow sparse cargo registry by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ fn real_main(options: Options, config: &mut Config) -> CargoResult<()> {
         .with_context(|| format!("failed to create index: `{}`", index.display()))?;
     let id = match options.flag_host {
         Some(ref s) => SourceId::for_registry(&Url::parse(s)?)?,
-        None => SourceId::crates_io(config)?,
+        None => SourceId::crates_io_maybe_sparse_http(config)?,
     };
 
     let lockfile = match options.flag_sync {


### PR DESCRIPTION
0.2.5 broke our build, apparantly because the bump from cargo 0.69 to 0.71 [enabled the sparse registry by default](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html).